### PR TITLE
fix for returning when plates are shorter than 8 characters

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -52,6 +52,7 @@ AddEventHandler('eden_garage:modifystate', function(vehicle, state)
 	print('UPDATING STATE...')
 	if plate ~= nil then
 		print('plate')
+		plate = plate:gsub("^%s*(.-)%s*$", "%1")
 		print(plate)
 	else
 		print('vehicle')


### PR DESCRIPTION
this trims the spaces around the license plate, in case game decides to add any spaces around (which it usually does). this allows vehicles with plates starting/ending with spaces to be returned again.